### PR TITLE
Feat/praise_audit cog

### DIFF
--- a/ext/praise_audit.py
+++ b/ext/praise_audit.py
@@ -31,7 +31,7 @@ class PraiseAudit(commands.Cog):
             # praise from server creation date
             after = ctx.guild.created_at
 
-        clean_msgs = [["To", "From", "Reason for Dishing", "Date", "Server", "Room"]]
+        clean_msgs = [["To", "From", "Reason for Dishing", "Server", "Date", "Room"]]
         msg_logs = dict()
         praise_duration = f"from {after.strftime('%b-%d-%Y')}"
         # Ignore these channels, to reduce API calls
@@ -84,8 +84,8 @@ class PraiseAudit(commands.Cog):
                                 )
                                 .strip()
                                 .replace("\n", " "),
-                                timestamp,
                                 msg.guild.name,
+                                timestamp,
                                 msg.channel.name,
                             ]
                             if timestamp not in msg_logs:

--- a/ext/praise_audit.py
+++ b/ext/praise_audit.py
@@ -1,0 +1,92 @@
+import re
+import csv
+import logging
+
+from asyncio import sleep
+from datetime import datetime, timedelta
+from collections import OrderedDict
+
+from discord import utils, File
+from discord.ext import commands
+from discord.ext.commands import Context
+from discord.errors import Forbidden, HTTPException
+
+
+log = logging.getLogger(__name__)
+
+class PraiseAudit(commands.Cog):
+    """Commands for scraping old praise from the server"""
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command()
+    async def praise_audit(self, ctx: Context, after: str = None):
+        await ctx.send(f'Fetching all Praise from {ctx.guild.name}...')
+
+        if after:
+            dates = [int(char) for char in after.split('-')]
+            after = datetime(dates[2], dates[1], dates[0])
+        else:
+            # praise from server creation date
+            after=ctx.guild.created_at
+
+        clean_msgs = [["To", "From", "Reason for Dishing", "Date", "Server", "Room"]]
+        msg_logs = OrderedDict()
+        praise_duration = f"from {after.strftime('%b-%d-%Y')}"
+
+        await ctx.send(f"Attempting to get praise {praise_duration}")
+        for channel in ctx.guild.text_channels:
+            await sleep(5)
+            try:
+                log.info(f"Attempting to get praise in {channel.name} {praise_duration}")
+                await ctx.send("Attemting to get praise in {channel.name}")
+
+                async for msg in channel.hostory(after=after, limit=None):
+                    if msg.content.startswith('!praise'):
+                        for person in msg.mentions:
+                            timestamp = msg.created_at.strftime("%b-%d-%Y")
+                            info = [
+                                person.name + "#" + person.discriminator,
+                                msg.author.name + "#" + msg.author.discriminator,
+                                re.sub(r'(<@).*?>', '', utils.escape_mentions(msg.content)[8:]).strip().replace('\n', ' '),
+                                msg.created_at.strftime("%b-%d-%Y"),
+                                msg.guild.name,
+                                msg.channel.name
+                            ]
+                            if timestamp not in msg_logs:
+                                msg_logs[timestamp] = []
+
+                            msg_logs[timestamp].append(info)
+                            log.info(f'Adding praise for: {person.name} - {msg.channel.name}')
+            except Forbidden:
+                log.error(f"Missing perms... Skipping praise scraping from channel - {channel.name}")
+                continue
+            else:
+                continue
+
+        for msg_log in msg_logs.values():
+            for msg_data in msg_log:
+                clean_msgs.append(msg_data)
+
+        with open(f"praise_audit_{ctx.guild.id}.csv", 'w') as f:
+            try:
+                writer = csv.writer(f)
+                log.info('Writing Praise...')
+                writer.writerows(clean_msgs)
+            except Exception as e:
+                log.error(f"Error in writing Praise: {e}")
+
+            log.info("Praise successfully written!")
+        await ctx.send("Praise collected and written!")
+        await ctx.send(
+            f"Praise written! Here's all of the Praise in the server for the audit",
+            file = File(f'praise_audit_{ctx.guild.id}.csv', f'{ctx.guild.name} praise.csv')
+        )
+    @praise_audit.error
+    async def get_praise_error(self, ctx: Context, error):
+        if isinstance(error.original, HTTPException):
+            await ctx.send("An error occured, the date format might be wrong.")
+        log.error(f"An error occured\n{error}")
+
+def setup(bot):
+    bot.add_cog(PraiseAudit(bot))

--- a/ext/praise_audit.py
+++ b/ext/praise_audit.py
@@ -1,34 +1,35 @@
-import re
 import csv
 import logging
-
+import re
 from asyncio import sleep
 from datetime import datetime, timedelta
-from collections import OrderedDict
 
-from discord import utils, File
+from discord import File, utils
+from discord.errors import Forbidden, HTTPException
 from discord.ext import commands
 from discord.ext.commands import Context
-from discord.errors import Forbidden, HTTPException
-
 
 log = logging.getLogger(__name__)
 
+
 class PraiseAudit(commands.Cog):
     """Commands for scraping old praise from the server"""
+
     def __init__(self, bot):
         self.bot = bot
 
     @commands.command()
     async def praise_audit(self, ctx: Context, after: str = None):
-        await ctx.send(f'Fetching all the Praise from {ctx.guild.name} for the Audit...')
+        await ctx.send(
+            f"Fetching all the Praise from {ctx.guild.name} for the Audit..."
+        )
 
         if after:
-            dates = [int(char) for char in after.split('-')]
+            dates = [int(char) for char in after.split("-")]
             after = datetime(dates[2], dates[1], dates[0])
         else:
             # praise from server creation date
-            after=ctx.guild.created_at
+            after = ctx.guild.created_at
 
         clean_msgs = [["To", "From", "Reason for Dishing", "Date", "Server", "Room"]]
         msg_logs = dict()
@@ -36,22 +37,22 @@ class PraiseAudit(commands.Cog):
         # Ignore these channels, to reduce API calls
         # TODO: Re-implement this list to be more DRY, and be located in a config file
         skip_channels = [
-            810183289863798815, # join-here (TEC)
-            831938823172653076, # announcements (TEC)
-            810180622336262197, # tec-tokenholders
-            810180622966325296, # ECOSYSTEM
-            810180622966325291, # ECOSYSTEM
-            810180622966325292, # ECOSYSTEM
-            810180622966325293, # ECOSYSTEM
-            810180622966325294, # ECOSYSTEM
-            810180622966325295, # ECOSYSTEM
-            857623810455109692, # ECOSYSTEM
-            778081852492873758, # rules (CS)
-            780557396778549330, # announcements (CS)
-            824917827831595028, # claim-a-role (CS)
-            778081852492873759, # moderator-only (CS)
-            778085977125158922, # system-messages (CS)
-            801882792942239818  # praise-testing (CS)
+            810183289863798815,  # join-here (TEC)
+            831938823172653076,  # announcements (TEC)
+            810180622336262197,  # tec-tokenholders
+            810180622966325296,  # ECOSYSTEM
+            810180622966325291,  # ECOSYSTEM
+            810180622966325292,  # ECOSYSTEM
+            810180622966325293,  # ECOSYSTEM
+            810180622966325294,  # ECOSYSTEM
+            810180622966325295,  # ECOSYSTEM
+            857623810455109692,  # ECOSYSTEM
+            778081852492873758,  # rules (CS)
+            780557396778549330,  # announcements (CS)
+            824917827831595028,  # claim-a-role (CS)
+            778081852492873759,  # moderator-only (CS)
+            778085977125158922,  # system-messages (CS)
+            801882792942239818,  # praise-testing (CS)
         ]
 
         await ctx.send(f"Attempting to get praise {praise_duration}")
@@ -65,39 +66,53 @@ class PraiseAudit(commands.Cog):
                     log.info(f"Skipping {channel.name} from praise-audit")
                 else:
                     await ctx.send(f"Attempting to get praise in {channel.name}")
-                    log.info(f"Attempting to get praise in {channel.name} {praise_duration}")
+                    log.info(
+                        f"Attempting to get praise in {channel.name} {praise_duration}"
+                    )
 
                 async for msg in channel.history(after=after, limit=None):
-                    if msg.content.startswith('!praise'):
+                    if msg.content.startswith("!praise"):
                         for person in msg.mentions:
                             timestamp = msg.created_at.strftime("%b-%d-%Y")
                             info = [
                                 person.name + "#" + person.discriminator,
                                 msg.author.name + "#" + msg.author.discriminator,
-                                re.sub(r'(<@).*?>', '', utils.escape_mentions(msg.content)[8:]).strip().replace('\n', ' '),
+                                re.sub(
+                                    r"(<@).*?>",
+                                    "",
+                                    utils.escape_mentions(msg.content)[8:],
+                                )
+                                .strip()
+                                .replace("\n", " "),
                                 timestamp,
                                 msg.guild.name,
-                                msg.channel.name
+                                msg.channel.name,
                             ]
                             if timestamp not in msg_logs:
                                 msg_logs[timestamp] = []
 
                             msg_logs[timestamp].append(info)
-                            log.info(f'Adding praise for: {person.name} - {msg.channel.name}')
+                            log.info(
+                                f"Adding praise for: {person.name} - {msg.channel.name}"
+                            )
             except Forbidden:
-                log.error(f"Missing perms... Skipping praise scraping from channel - {channel.name}")
+                log.error(
+                    f"Missing perms... Skipping praise scraping from channel - {channel.name}"
+                )
                 continue
             else:
                 continue
 
-        for date in sorted(msg_logs.keys(), key=lambda x: datetime.strptime(x, '%b-%d-%Y')):
+        for date in sorted(
+            msg_logs.keys(), key=lambda x: datetime.strptime(x, "%b-%d-%Y")
+        ):
             for msg_data in msg_logs[date]:
                 clean_msgs.append(msg_data)
 
-        with open(f"praise_audit_{ctx.guild.id}.csv", 'w') as f:
+        with open(f"praise_audit_{ctx.guild.id}.csv", "w") as f:
             try:
                 writer = csv.writer(f)
-                log.info('Writing Praise...')
+                log.info("Writing Praise...")
                 writer.writerows(clean_msgs)
             except Exception as e:
                 log.error(f"Error in writing Praise: {e}")
@@ -106,13 +121,17 @@ class PraiseAudit(commands.Cog):
         await ctx.send("Praise collected and written!")
         await ctx.send(
             f"Praise written! Here's all of the Praise in the server for the audit",
-            file = File(f'praise_audit_{ctx.guild.id}.csv', f'{ctx.guild.name} praise.csv')
+            file=File(
+                f"praise_audit_{ctx.guild.id}.csv", f"{ctx.guild.name} praise.csv"
+            ),
         )
+
     @praise_audit.error
     async def get_praise_error(self, ctx: Context, error):
         if isinstance(error.original, HTTPException):
             await ctx.send("An error occured, the date format might be wrong.")
         log.error(f"An error occured\n{error}")
+
 
 def setup(bot):
     bot.add_cog(PraiseAudit(bot))

--- a/ext/scrape_praise.py
+++ b/ext/scrape_praise.py
@@ -28,7 +28,7 @@ class PraiseScrape(commands.Cog):
             # praise from 20 days ago from now
             after=datetime.now() - timedelta(days=20)
 
-        clean_msgs = [["To", "From", "Reason for Dishing", "Date", "Room"]]
+        clean_msgs = [["To", "From", "Reason for Dishing", "Date", "Server", "Room"]]
         for channel in ctx.guild.text_channels:
             await sleep(5)
             try:
@@ -43,6 +43,7 @@ class PraiseScrape(commands.Cog):
                                     msg.author.name + "#" + msg.author.discriminator,
                                     re.sub(r'(<@).*?>', '', utils.escape_mentions(msg.content)[8:]).strip().replace('\n', ' '),
                                     msg.created_at.strftime("%b-%d-%Y"),
+                                    msg.guild.name,
                                     msg.channel.name
                                 ]
                             )

--- a/main.py
+++ b/main.py
@@ -17,6 +17,8 @@ logging.basicConfig(filename='praise.log', level=logging.INFO, format='%(asctime
 
 #load scrape_praise extension
 bot.load_extension('ext.scrape_praise')
+#loade praise_audit extension
+bot.load_extension('ext.praise_audit')
 
 def get_creds():
     # To obtain a service account JSON file, follow these steps:


### PR DESCRIPTION
### Description: 

This PR adds an `audit` feature to the bot.
Initially, this was supposed to fetch messages in fractions but currently, discord.py doesn't support that.
The implementation is similar to the `scrape_praise.py` script, but this is slightly better and sorts the data according to the dates(*at the cost of more memory)

Ideally, maybe we can maybe remove the `scrape_praise` cog if we adopt this cog, though keeping both can also be useful. (that's your call @hurek)

This would need a clean-up, to make it more DRY, however for now this would work fine for the Praise Audits on CommonsStack and TokenEngineeringCommons

#### syntax:
`!praise_audit <date>`
   \- `date` is an optional argument and has to be in the format - `dd-mm-yyyy`(*without any preceding zeros in single digit units, i.e. `8-11-2021` instead of `08-11-2021`)
   
#### screenshots:
![Screenshot 2021-07-08 at 12 35 08 AM](https://user-images.githubusercontent.com/62864373/124815035-5df5d080-df84-11eb-9c3f-7b7194d2cdef.png)
![Screenshot 2021-07-08 at 12 35 42 AM](https://user-images.githubusercontent.com/62864373/124815077-7534be00-df84-11eb-878f-e6d04f975416.png)

